### PR TITLE
Use correct function signature for L2 -> L1 communication

### DIFF
--- a/contracts/bridges/L2_Bridge.sol
+++ b/contracts/bridges/L2_Bridge.sol
@@ -173,8 +173,9 @@ abstract contract L2_Bridge is ERC20, Bridge {
         emit TransfersCommitted(root,totalAmount);
 
         bytes memory confirmTransferRootMessage = abi.encodeWithSignature(
-            "confirmTransferRoot(bytes32,uint256)",
+            "confirmTransferRoot(bytes32,uint256,uint256)",
             root,
+            _destinationChainId,
             totalAmount
         );
 


### PR DESCRIPTION
@cwhinfrey looks like this was unintentionally changed [here](https://github.com/hop-exchange/contracts/pull/4/files#diff-722967aae5c34b1354ee9cab3d71180d9826216183c67297ce096cf48930a583R176).

Please merge if this fix is ok.