### PR TITLE
Feature/naming

### DIFF
--- a/contracts/bridges/L1_Bridge.sol
+++ b/contracts/bridges/L1_Bridge.sol
@@ -221,8 +221,10 @@ contract L1_Bridge is Bridge, L1_BridgeConfig {
             _addCredit(getBondForTransferAmount(transferRoot.total).add(challengeStakeAmount));
         } else {
             // Valid challenge
-            // Reward challenger with their stake times two
-            l1CanonicalToken.transfer(transferBond.challenger, challengeStakeAmount.mul(2));
+            // Burn 25% of the challengers stake
+            l1CanonicalToken.transfer(address(0xd3ad), challengeStakeAmount.mul(1).div(4));
+            // Reward challenger with the remaining 75% of their stake plus 100% of the Bonder's stake
+            l1CanonicalToken.transfer(transferBond.challenger, challengeStakeAmount.mul(7).div(4));
         }
     }
 


### PR DESCRIPTION
* Naming changes
* Add 25% burn on challenge resolution. It's only needed for valid challenges because the bonder is front-run a challenge of their own fraudulent Transfer Root. A Bonder making invalid challenges against their own valid Transfer Roots would be pointless and just waste gas. 