### PR TITLE
Feature/internal audit

### DIFF
--- a/contracts/bridges/Accounting.sol
+++ b/contracts/bridges/Accounting.sol
@@ -62,7 +62,9 @@ abstract contract Accounting {
     }
 
     /* ========== Virtual functions ========== */
-
+    /**
+     * @dev The following functions are overriden in L1_Bridge and L2_Bridge
+     */
     function _transferFromBridge(address recipient, uint256 amount) internal virtual;
     function _transferToBridge(address from, uint256 amount) internal virtual;
     function _requireIsGovernance() internal virtual;

--- a/contracts/bridges/Bridge.sol
+++ b/contracts/bridges/Bridge.sol
@@ -236,14 +236,16 @@ abstract contract Bridge is Accounting {
         address bonder,
         bytes32 transferId,
         bytes32 rootHash,
+        uint256 transferRootTotalAmount,
         bytes32[] memory proof
     )
         public
     {
         require(proof.verify(rootHash, transferId), "L2_BRG: Invalid transfer proof");
 
+        bytes32 transferRootId = getTransferRootId(rootHash, transferRootTotalAmount);
         uint256 amount = _bondedWithdrawalAmounts[bonder][transferId];
-        _addToAmountWithdrawn(rootHash, amount);
+        _addToAmountWithdrawn(transferRootId, amount);
 
         _bondedWithdrawalAmounts[bonder][transferId] = 0;
         _addCredit(bonder, amount);

--- a/contracts/bridges/Bridge.sol
+++ b/contracts/bridges/Bridge.sol
@@ -217,8 +217,7 @@ abstract contract Bridge is Accounting {
             0
         );
 
-        _addDebit(msg.sender, amount);
-        _setBondedWithdrawalAmountForSender(transferId, amount);
+        _bondWithdrawal(transferId, amount);
         _fulfillWithdraw(transferId, recipient, amount, relayerFee);
 
         emit WithdrawalBonded(transferId, sender, recipient, amount, transferNonce, relayerFee);
@@ -312,8 +311,9 @@ abstract contract Bridge is Accounting {
         _transferRoots[transferRootId] = TransferRoot(amount, 0);
     }
 
-    function _setBondedWithdrawalAmountForSender(bytes32 transferId, uint256 amount) internal {
+    function _bondWithdrawal(bytes32 transferId, uint256 amount) internal {
         require(_bondedWithdrawalAmounts[msg.sender][transferId] == 0, "BRG: Withdrawal has already been bonded");
+        _addDebit(msg.sender, amount);
         _bondedWithdrawalAmounts[msg.sender][transferId] = amount;
     }
 

--- a/contracts/bridges/L2_Bridge.sol
+++ b/contracts/bridges/L2_Bridge.sol
@@ -243,8 +243,7 @@ abstract contract L2_Bridge is ERC20, Bridge {
             deadline
         );
 
-        _addDebit(msg.sender, amount);
-        _setBondedWithdrawalAmountForSender(transferId, amount);
+        _bondWithdrawal(transferId, amount);
         _withdrawAndAttemptSwap(transferId, recipient, amount, relayerFee, amountOutMin, deadline);
     }
 


### PR DESCRIPTION
* Use transferRootId in settleBondedWithdrawal
*  _setBondedWithdrawalAmountForSender -> _bondWithdrawal
* Prevent challengeTransferBond and resolveChallenge from being called twice