### PR TITLE
contracts: autogenerate nonce

### DIFF
--- a/contracts/bridges/Bridge.sol
+++ b/contracts/bridges/Bridge.sol
@@ -31,7 +31,7 @@ abstract contract Bridge is Accounting {
         address indexed sender,
         address indexed recipient,
         uint256 amount,
-        uint256 transferNonce,
+        bytes32 transferNonce,
         uint256 relayerFee
     );
 
@@ -40,7 +40,7 @@ abstract contract Bridge is Accounting {
         address indexed sender,
         address indexed recipient,
         uint256 amount,
-        uint256 transferNonce,
+        bytes32 transferNonce,
         uint256 relayerFee
     );
 
@@ -84,7 +84,7 @@ abstract contract Bridge is Accounting {
         address sender,
         address recipient,
         uint256 amount,
-        uint256 transferNonce,
+        bytes32 transferNonce,
         uint256 relayerFee,
         uint256 amountOutMin,
         uint256 deadline
@@ -160,7 +160,7 @@ abstract contract Bridge is Accounting {
         address sender,
         address recipient,
         uint256 amount,
-        uint256 transferNonce,
+        bytes32 transferNonce,
         uint256 relayerFee,
         bytes32 transferRootId,
         bytes32[] memory proof
@@ -185,8 +185,6 @@ abstract contract Bridge is Accounting {
         emit Withdrew(transferId, sender, recipient, amount, transferNonce, relayerFee);
     }
 
-    // ToDo: enforce _transferNonce can't collide on send or autogenerate nonce
-
     /**
      * @dev Allows the bonder to bond individual withdrawals before their TransferRoot has been committed.
      * @param sender The address sending the Transfer
@@ -199,7 +197,7 @@ abstract contract Bridge is Accounting {
         address sender,
         address recipient,
         uint256 amount,
-        uint256 transferNonce,
+        bytes32 transferNonce,
         uint256 relayerFee
     )
         public


### PR DESCRIPTION
* `transferNonce` is now `bytes32`
* calculated by taking the hash of an incrementer and the origin chainId

__Why?__
This allows us to assign a unique nonce and therefor unique transferId to every transfer without any risk of collision across multiple independent chains. We could alternatively use the origin chainId in the `getTransferId` calculation but then we'd have to pass it in to all of the withdraw functions. 