### PR TITLE
Feature/internal audit fixes

### DIFF
--- a/contracts/bridges/Accounting.sol
+++ b/contracts/bridges/Accounting.sol
@@ -99,6 +99,7 @@ abstract contract Accounting {
      * @param amount The amount being staked
      */
     function stake(address bonder, uint256 amount) external {
+        require(_isBonder[bonder] == true, "ACT: Address is not bonder");
         _transferToBridge(msg.sender, amount);
         _addCredit(bonder, amount);
     }
@@ -118,7 +119,7 @@ abstract contract Accounting {
     }
 
     function removeBonder(address bonder) external onlyGovernance {
-        require(_isBonder[bonder] == true, "ACT: Address is Bonder");
+        require(_isBonder[bonder] == true, "ACT: Address is not Bonder");
         _isBonder[bonder] = false;
     }
 

--- a/contracts/bridges/Accounting.sol
+++ b/contracts/bridges/Accounting.sol
@@ -78,7 +78,7 @@ abstract contract Accounting {
         return 0;
     }
 
-    /* ========== Public getters ========== */
+    /* ========== Public/external getters ========== */
 
     function getIsBonder(address maybeBonder) public view returns (bool) {
         return _isBonder[maybeBonder];
@@ -96,7 +96,7 @@ abstract contract Accounting {
         return _debit[bonder].add(_additionalDebit());
     }
 
-    /* ========== Bonder public functions ========== */
+    /* ========== Bonder external functions ========== */
 
     /** 
      * @dev Allows the bonder to deposit tokens and increase its credit balance

--- a/contracts/bridges/Accounting.sol
+++ b/contracts/bridges/Accounting.sol
@@ -88,6 +88,10 @@ abstract contract Accounting {
         return _credit[bonder];
     }
 
+    function getRawDebit(address bonder) external view returns (uint256) {
+        return _debit[bonder];
+    }
+
     function getDebitAndAdditionalDebit(address bonder) public view returns (uint256) {
         return _debit[bonder].add(_additionalDebit());
     }

--- a/contracts/bridges/Bridge.sol
+++ b/contracts/bridges/Bridge.sol
@@ -64,7 +64,7 @@ abstract contract Bridge is Accounting {
 
     constructor(address[] memory bonders) public Accounting(bonders) {}
 
-    /* ========== Public getters ========== */
+    /* ========== Public Getters ========== */
 
     /**
      * @dev Get the hash that represents an individual Transfer.
@@ -143,7 +143,7 @@ abstract contract Bridge is Accounting {
         return _bondedWithdrawalAmounts[bonder][transferId];
     }
 
-    /* ========== User/relayer public functions ========== */
+    /* ========== User/Relayer External Functions ========== */
 
     /**
      * @notice Can be called by anyone (recipient or relayer)
@@ -165,7 +165,7 @@ abstract contract Bridge is Accounting {
         bytes32 transferRootId,
         bytes32[] memory proof
     )
-        public
+        external
     {
         bytes32 transferId = getTransferId(
             getChainId(),
@@ -200,7 +200,7 @@ abstract contract Bridge is Accounting {
         bytes32 transferNonce,
         uint256 relayerFee
     )
-        public
+        external
         onlyBonder
         requirePositiveBalance
     {
@@ -236,7 +236,7 @@ abstract contract Bridge is Accounting {
         uint256 transferRootTotalAmount,
         bytes32[] memory proof
     )
-        public
+        external
     {
         require(proof.verify(rootHash, transferId), "L2_BRG: Invalid transfer proof");
 
@@ -255,7 +255,7 @@ abstract contract Bridge is Accounting {
         bytes32[] memory transferIds,
         uint256 totalAmount
     )
-        public
+        external
     {
         bytes32 rootHash = MerkleUtils.getMerkleRoot(transferIds);
 
@@ -279,7 +279,7 @@ abstract contract Bridge is Accounting {
         emit MultipleWithdrawalsSettled(bonder, rootHash, totalBondsSettled);
     }
 
-    /* ========== Internal functions ========== */
+    /* ========== Internal Functions ========== */
 
     function _markTransferSpent(bytes32 transferId) internal {
         require(!_spentTransferIds[transferId], "BRG: The transfer has already been withdrawn");
@@ -315,7 +315,7 @@ abstract contract Bridge is Accounting {
         _bondedWithdrawalAmounts[msg.sender][transferId] = amount;
     }
 
-    /* ========== Private functions ========== */
+    /* ========== Private Functions ========== */
 
     /// @dev Completes the Transfer, distributes the relayer fee and marks the Transfer as spent.
     function _fulfillWithdraw(

--- a/contracts/bridges/L1_Bridge.sol
+++ b/contracts/bridges/L1_Bridge.sol
@@ -236,7 +236,7 @@ contract L1_Bridge is Bridge {
         require(challengePeriodEnd >= block.timestamp, "L1_BRG: Transfer root cannot be challenged after challenge period");
         require(transferBond.challengeStartTime == 0, "L1_BRG: Transfer root already challenged");
 
-        transferBond.challengeStartTime = now;
+        transferBond.challengeStartTime = block.timestamp;
         transferBond.challenger = msg.sender;
 
         // Move amount from timeSlotToAmountBonded to debit
@@ -260,7 +260,7 @@ contract L1_Bridge is Bridge {
 
         require(transferRoot.total > 0, "L1_BRG: Transfer root not found");
         require(transferBond.challengeStartTime != 0, "L1_BRG: Transfer root has not been challenged");
-        require(now > transferBond.challengeStartTime.add(challengeResolutionPeriod), "L1_BRG: Challenge period has not ended");
+        require(block.timestamp > transferBond.challengeStartTime.add(challengeResolutionPeriod), "L1_BRG: Challenge period has not ended");
         require(transferBond.challengeResolved == false, "L1_BRG: Transfer root already resolved");
         transferBond.challengeResolved = true;
 
@@ -292,7 +292,7 @@ contract L1_Bridge is Bridge {
     }
 
     function _additionalDebit() internal view override returns (uint256) {
-        uint256 currentTimeSlot = getTimeSlot(now);
+        uint256 currentTimeSlot = getTimeSlot(block.timestamp);
         uint256 bonded = 0;
 
         for (uint256 i = 0; i < 4; i++) {

--- a/contracts/bridges/L1_Bridge.sol
+++ b/contracts/bridges/L1_Bridge.sol
@@ -225,9 +225,9 @@ contract L1_Bridge is Bridge {
 
     /* ========== Public TransferRoot Challenges ========== */
 
-    function challengeTransferBond(bytes32 rootHash, uint256 originalAmount) public {
-        bytes32 transferRootId = getTransferRootId(rootHash, originalAmount);
-        TransferRoot memory transferRoot = getTransferRoot(rootHash, originalAmount);
+    function challengeTransferBond(bytes32 rootHash, uint256 totalAmountBonded) public {
+        bytes32 transferRootId = getTransferRootId(rootHash, totalAmountBonded);
+        TransferRoot memory transferRoot = getTransferRoot(rootHash, totalAmountBonded);
         TransferBond storage transferBond = transferBonds[transferRootId];
 
         require(transferRoot.total > 0, "L1_BRG: TransferRoot not found");

--- a/contracts/bridges/L1_Bridge.sol
+++ b/contracts/bridges/L1_Bridge.sol
@@ -258,6 +258,7 @@ contract L1_Bridge is Bridge {
         TransferRoot memory transferRoot = getTransferRoot(rootHash, originalAmount);
         TransferBond storage transferBond = transferBonds[transferRootId];
 
+        require(transferRoot.total > 0, "L1_BRG: Transfer root not found");
         require(transferBond.challengeStartTime != 0, "L1_BRG: Transfer root has not been challenged");
         require(now > transferBond.challengeStartTime.add(challengeResolutionPeriod), "L1_BRG: Challenge period has not ended");
         require(transferBond.challengeResolved == false, "L1_BRG: Transfer root already resolved");

--- a/contracts/bridges/L1_Bridge.sol
+++ b/contracts/bridges/L1_Bridge.sol
@@ -248,9 +248,9 @@ contract L1_Bridge is Bridge {
 
         // Get stake for challenge
         uint256 challengeStakeAmount = getChallengeAmountForTransferAmount(transferRoot.total);
-        l1CanonicalToken.transferFrom(msg.sender, address(this), challengeStakeAmount);
+        l1CanonicalToken.safeTransferFrom(msg.sender, address(this), challengeStakeAmount);
 
-        emit TransferBondChallenged(transferRootId, rootHash, originalAmount);
+        emit TransferBondChallenged(transferRootId, rootHash, totalAmountBonded);
     }
 
     function resolveChallenge(bytes32 rootHash, uint256 originalAmount) public {
@@ -273,9 +273,9 @@ contract L1_Bridge is Bridge {
         } else {
             // Valid challenge
             // Burn 25% of the challengers stake
-            l1CanonicalToken.transfer(address(0xdead), challengeStakeAmount.mul(1).div(4));
+            l1CanonicalToken.safeTransfer(address(0xdead), challengeStakeAmount.mul(1).div(4));
             // Reward challenger with the remaining 75% of their stake plus 100% of the Bonder's stake
-            l1CanonicalToken.transfer(transferBond.challenger, challengeStakeAmount.mul(7).div(4));
+            l1CanonicalToken.safeTransfer(transferBond.challenger, challengeStakeAmount.mul(7).div(4));
         }
 
         emit ChallengeResolved(transferRootId, rootHash, originalAmount);

--- a/contracts/bridges/L1_Bridge.sol
+++ b/contracts/bridges/L1_Bridge.sol
@@ -126,7 +126,7 @@ contract L1_Bridge is Bridge {
         messengerWrapper.sendCrossDomainMessage(mintAndAttemptSwapCalldata);
     }
 
-    /* ========== Public Transfer Root Functions ========== */
+    /* ========== Public TransferRoot Functions ========== */
 
     /**
      * @dev Setting a TransferRoot is a two step process.
@@ -152,8 +152,8 @@ contract L1_Bridge is Bridge {
         requirePositiveBalance
     {
         bytes32 transferRootId = getTransferRootId(rootHash, totalAmount);
-        require(transferRootConfirmed[transferRootId] == false, "L1_BRG: Transfer Root has already been confirmed");
-        require(transferBonds[transferRootId].createdAt == 0, "L1_BRG: Transfer Root has already been bonded");
+        require(transferRootConfirmed[transferRootId] == false, "L1_BRG: TransferRoot has already been confirmed");
+        require(transferBonds[transferRootId].createdAt == 0, "L1_BRG: TransferRoot has already been bonded");
 
         uint256 currentTimeSlot = getTimeSlot(block.timestamp);
         uint256 bondAmount = getBondForTransferAmount(totalAmount);
@@ -207,13 +207,13 @@ contract L1_Bridge is Bridge {
     {
         // Set TransferRoot on recipient Bridge
         if (chainId == getChainId()) {
-            // Set L1 transfer root
+            // Set L1 TransferRoot
             _setTransferRoot(rootHash, totalAmount);
         } else {
             IMessengerWrapper messengerWrapper = crossDomainMessengerWrappers[chainId];
             require(messengerWrapper != IMessengerWrapper(0), "L1_BRG: chainId not supported");
 
-            // Set L2 transfer root
+            // Set L2 TransferRoot
             bytes memory setTransferRootMessage = abi.encodeWithSignature(
                 "setTransferRoot(bytes32,uint256)",
                 rootHash,
@@ -230,11 +230,11 @@ contract L1_Bridge is Bridge {
         TransferRoot memory transferRoot = getTransferRoot(rootHash, originalAmount);
         TransferBond storage transferBond = transferBonds[transferRootId];
 
-        require(transferRoot.total > 0, "L1_BRG: Transfer root not found");
-        require(transferRootConfirmed[transferRootId] == false, "L1_BRG: Transfer root has already been confirmed");
+        require(transferRoot.total > 0, "L1_BRG: TransferRoot not found");
+        require(transferRootConfirmed[transferRootId] == false, "L1_BRG: TransferRoot has already been confirmed");
         uint256 challengePeriodEnd = transferBond.createdAt.add(challengePeriod);
-        require(challengePeriodEnd >= block.timestamp, "L1_BRG: Transfer root cannot be challenged after challenge period");
-        require(transferBond.challengeStartTime == 0, "L1_BRG: Transfer root already challenged");
+        require(challengePeriodEnd >= block.timestamp, "L1_BRG: TransferRoot cannot be challenged after challenge period");
+        require(transferBond.challengeStartTime == 0, "L1_BRG: TransferRoot already challenged");
 
         transferBond.challengeStartTime = block.timestamp;
         transferBond.challenger = msg.sender;
@@ -258,10 +258,10 @@ contract L1_Bridge is Bridge {
         TransferRoot memory transferRoot = getTransferRoot(rootHash, originalAmount);
         TransferBond storage transferBond = transferBonds[transferRootId];
 
-        require(transferRoot.total > 0, "L1_BRG: Transfer root not found");
-        require(transferBond.challengeStartTime != 0, "L1_BRG: Transfer root has not been challenged");
+        require(transferRoot.total > 0, "L1_BRG: TransferRoot not found");
+        require(transferBond.challengeStartTime != 0, "L1_BRG: TransferRoot has not been challenged");
         require(block.timestamp > transferBond.challengeStartTime.add(challengeResolutionPeriod), "L1_BRG: Challenge period has not ended");
-        require(transferBond.challengeResolved == false, "L1_BRG: Transfer root already resolved");
+        require(transferBond.challengeResolved == false, "L1_BRG: TransferRoot already resolved");
         transferBond.challengeResolved = true;
 
         uint256 challengeStakeAmount = getChallengeAmountForTransferAmount(transferRoot.total);

--- a/contracts/bridges/L1_Bridge.sol
+++ b/contracts/bridges/L1_Bridge.sol
@@ -87,7 +87,7 @@ contract L1_Bridge is Bridge {
         address recipient,
         uint256 amount
     )
-        public
+        external
     {
         IMessengerWrapper messengerWrapper = crossDomainMessengerWrappers[chainId];
         require(messengerWrapper != IMessengerWrapper(0), "L1_BRG: chainId not supported");
@@ -107,7 +107,7 @@ contract L1_Bridge is Bridge {
         uint256 amountOutMin,
         uint256 deadline
     )
-        public
+        external
     {
         IMessengerWrapper messengerWrapper = crossDomainMessengerWrappers[chainId];
         require(messengerWrapper != IMessengerWrapper(0), "L1_BRG: chainId not supported");
@@ -180,7 +180,7 @@ contract L1_Bridge is Bridge {
         bytes32 rootHash,
         uint256 totalAmount
     )
-        public
+        external
         onlyL2Bridge(originChainId)
     {
         bytes32 transferRootId = getTransferRootId(rootHash, totalAmount);
@@ -223,9 +223,9 @@ contract L1_Bridge is Bridge {
         }
     }
 
-    /* ========== Public TransferRoot Challenges ========== */
+    /* ========== External TransferRoot Challenges ========== */
 
-    function challengeTransferBond(bytes32 rootHash, uint256 totalAmountBonded) public {
+    function challengeTransferBond(bytes32 rootHash, uint256 totalAmountBonded) external {
         bytes32 transferRootId = getTransferRootId(rootHash, totalAmountBonded);
         TransferRoot memory transferRoot = getTransferRoot(rootHash, totalAmountBonded);
         TransferBond storage transferBond = transferBonds[transferRootId];
@@ -253,7 +253,7 @@ contract L1_Bridge is Bridge {
         emit TransferBondChallenged(transferRootId, rootHash, totalAmountBonded);
     }
 
-    function resolveChallenge(bytes32 rootHash, uint256 originalAmount) public {
+    function resolveChallenge(bytes32 rootHash, uint256 originalAmount) external {
         bytes32 transferRootId = getTransferRootId(rootHash, originalAmount);
         TransferRoot memory transferRoot = getTransferRoot(rootHash, originalAmount);
         TransferBond storage transferBond = transferBonds[transferRootId];
@@ -281,7 +281,7 @@ contract L1_Bridge is Bridge {
         emit ChallengeResolved(transferRootId, rootHash, originalAmount);
     }
 
-    /* ========== Override functions ========== */
+    /* ========== Override Functions ========== */
 
     function _transferFromBridge(address recipient, uint256 amount) internal override {
         l1CanonicalToken.safeTransfer(recipient, amount);

--- a/contracts/bridges/L2_Bridge.sol
+++ b/contracts/bridges/L2_Bridge.sol
@@ -79,33 +79,33 @@ abstract contract L2_Bridge is ERC20, Bridge {
     function _sendCrossDomainMessage(bytes memory message) internal virtual;
     function _verifySender(address expectedSender) internal virtual; 
 
-    /* ========== Public functions ========== */
+    /* ========== Public/External functions ========== */
 
-    function setExchangeAddress(address _exchangeAddress) public onlyGovernance {
+    function setExchangeAddress(address _exchangeAddress) external onlyGovernance {
         exchangeAddress = _exchangeAddress;
     }
 
-    function setL1BridgeAddress(address _l1BridgeAddress) public onlyGovernance {
+    function setL1BridgeAddress(address _l1BridgeAddress) external onlyGovernance {
         l1BridgeAddress = _l1BridgeAddress;
     }
 
-    function setMessengerGasLimit(uint256 _messengerGasLimit) public onlyGovernance {
+    function setMessengerGasLimit(uint256 _messengerGasLimit) external onlyGovernance {
         messengerGasLimit = _messengerGasLimit;
     }
 
-    function addSupportedChainIds(uint256[] calldata chainIds) public onlyGovernance {
+    function addSupportedChainIds(uint256[] calldata chainIds) external onlyGovernance {
         for (uint256 i = 0; i < chainIds.length; i++) {
             supportedChainIds[chainIds[i]] = true;
         }
     }
 
-    function removeSupportedChainIds(uint256[] calldata chainIds) public onlyGovernance {
+    function removeSupportedChainIds(uint256[] calldata chainIds) external onlyGovernance {
         for (uint256 i = 0; i < chainIds.length; i++) {
             supportedChainIds[chainIds[i]] = false;
         }
     }
 
-    function setMinimumForceCommitDelay(uint256 _minimumForceCommitDelay) public onlyGovernance {
+    function setMinimumForceCommitDelay(uint256 _minimumForceCommitDelay) external onlyGovernance {
         minimumForceCommitDelay = _minimumForceCommitDelay;
     }
 
@@ -163,7 +163,7 @@ abstract contract L2_Bridge is ERC20, Bridge {
         uint256 destinationAmountOutMin,
         uint256 destinationDeadline
     )
-        public
+        external
     {
         require(amount >= relayerFee, "L2_BRG: relayer fee cannot exceed amount");
 
@@ -193,11 +193,11 @@ abstract contract L2_Bridge is ERC20, Bridge {
         _commitTransfers(destinationChainId);
     }
 
-    function mint(address recipient, uint256 amount) public onlyL1Bridge {
+    function mint(address recipient, uint256 amount) external onlyL1Bridge {
         _mint(recipient, amount);
     }
 
-    function mintAndAttemptSwap(address _recipient, uint256 amount, uint256 amountOutMin, uint256 _deadline) public onlyL1Bridge {
+    function mintAndAttemptSwap(address _recipient, uint256 amount, uint256 amountOutMin, uint256 _deadline) external onlyL1Bridge {
         _mintAndAttemptSwap(_recipient, amount, amountOutMin, _deadline);
     }
 
@@ -212,7 +212,7 @@ abstract contract L2_Bridge is ERC20, Bridge {
         uint256 amountOutMin,
         uint256 deadline
     )
-        public
+        external
     {
         bytes32 transferId = getTransferId(
             getChainId(),
@@ -239,7 +239,7 @@ abstract contract L2_Bridge is ERC20, Bridge {
         uint256 amountOutMin,
         uint256 deadline
     )
-        public
+        external
         onlyBonder
         requirePositiveBalance
     {
@@ -258,7 +258,7 @@ abstract contract L2_Bridge is ERC20, Bridge {
         _withdrawAndAttemptSwap(transferId, recipient, amount, relayerFee, amountOutMin, deadline);
     }
 
-    function setTransferRoot(bytes32 rootHash, uint256 totalAmount) public onlyL1Bridge {
+    function setTransferRoot(bytes32 rootHash, uint256 totalAmount) external onlyL1Bridge {
         _setTransferRoot(rootHash, totalAmount);
     }
 

--- a/contracts/bridges/L2_Bridge.sol
+++ b/contracts/bridges/L2_Bridge.sol
@@ -167,7 +167,7 @@ abstract contract L2_Bridge is ERC20, Bridge {
     {
         require(amount >= relayerFee, "L2_BRG: relayer fee cannot exceed amount");
 
-        l2CanonicalToken.transferFrom(msg.sender, address(this), amount);
+        l2CanonicalToken.safeTransferFrom(msg.sender, address(this), amount);
 
         address[] memory exchangePath = _getCHPath();
         uint256[] memory swapAmounts = IUniswapV2Router02(exchangeAddress).getAmountsOut(amount, exchangePath);


### PR DESCRIPTION
* Add sanity check to stake
* Fail explicitly in resolveChallenge
* now -> block.timestamp
* Add getRawDebit getter
* transfer root -> TransferRoot
* originalAmount -> totalAmountBonded
* Use safeTransfer/safeTransferFrom
* Restrict public functions to external