### PR TITLE
Add the ability for the HopBridgeToken owner to change

### DIFF
--- a/contracts/bridges/L2_Bridge.sol
+++ b/contracts/bridges/L2_Bridge.sol
@@ -113,6 +113,10 @@ abstract contract L2_Bridge is Bridge {
         minimumForceCommitDelay = _minimumForceCommitDelay;
     }
 
+    function setHopBridgeTokenOwner(address newOwner) external onlyGovernance {
+        hToken.transferOwnership(newOwner);
+    }
+
     /// @notice _amount is the amount the user wants to send plus the relayer fee
     function send(
         uint256 chainId,

--- a/test/bridges/HopBridgeToken.test.ts
+++ b/test/bridges/HopBridgeToken.test.ts
@@ -1,0 +1,144 @@
+import '@nomiclabs/hardhat-waffle'
+import { expect } from 'chai'
+import { Signer, Contract, BigNumber } from 'ethers'
+
+import {
+  setUpDefaults,
+  revertSnapshot,
+  takeSnapshot
+} from '../shared/utils'
+import { fixture } from '../shared/fixtures'
+import { IFixture } from '../shared/interfaces'
+
+import {
+  CHAIN_IDS,
+  DEFAULT_H_TOKEN_NAME,
+  DEFAULT_H_TOKEN_SYMBOL,
+  DEFAULT_H_TOKEN_DECIMALS
+} from '../../config/constants'
+
+describe('L1_Bridge', () => {
+  let _fixture: IFixture
+  let l1ChainId: BigNumber
+  let l2ChainId: BigNumber
+
+  let user: Signer
+  let governance: Signer
+
+  let l2_hopBridgeToken: Contract
+  let l2_bridge: Contract
+
+  let beforeAllSnapshotId: string
+  let snapshotId: string
+
+  before(async () => {
+    beforeAllSnapshotId = await takeSnapshot()
+
+    l1ChainId = CHAIN_IDS.ETHEREUM.KOVAN
+    l2ChainId = CHAIN_IDS.OPTIMISM.TESTNET_1
+
+    _fixture = await fixture(l1ChainId, l2ChainId)
+    await setUpDefaults(_fixture, l2ChainId)
+    ;({
+      user,
+      governance,
+      l2_hopBridgeToken,
+      l2_bridge,
+    } = _fixture)
+  })
+
+  after(async() => {
+    await revertSnapshot(beforeAllSnapshotId)
+  })
+
+  // Take snapshot before each test and revert after each test
+  beforeEach(async() => {
+    snapshotId = await takeSnapshot()
+  })
+
+  afterEach(async() => {
+    await revertSnapshot(snapshotId)
+  })
+
+  /**
+   * End to end tests
+   */
+
+  it('Should correctly deploy an ERC20 and set the defined values', async () => {
+    const expectedL1GovernanceAddress: string = await governance.getAddress()
+    const expectedName: string = DEFAULT_H_TOKEN_NAME
+    const expectedSymbol: string = DEFAULT_H_TOKEN_SYMBOL
+    const expectedDecimals: number = DEFAULT_H_TOKEN_DECIMALS
+
+    const l1GovernanceAddress: string = await l2_hopBridgeToken.l1Governance()
+    const name: string = await l2_hopBridgeToken.name()
+    const symbol: string = await l2_hopBridgeToken.symbol()
+    const decimals: number = await l2_hopBridgeToken.decimals()
+    const totalSupply: BigNumber = await l2_hopBridgeToken.totalSupply()
+
+    expect(l1GovernanceAddress).to.eq(expectedL1GovernanceAddress)
+    expect(name).to.eq(expectedName)
+    expect(symbol).to.eq(expectedSymbol)
+    expect(decimals).to.eq(expectedDecimals)
+    expect(totalSupply).to.be.above(BigNumber.from('0'))
+  })
+
+  it('Should allow the owner to mint tokens', async () => {
+    // Set the owner to a known address for testing purposes
+    await l2_bridge.setHopBridgeTokenOwner(await user.getAddress())
+
+    const mintAmount: BigNumber = BigNumber.from('13371377')
+    const userBalanceBefore: BigNumber = await l2_hopBridgeToken.balanceOf(await user.getAddress())
+    const totalSupplyBefore: BigNumber = await l2_hopBridgeToken.totalSupply()
+
+    await l2_hopBridgeToken.connect(user).mint(await user.getAddress(), mintAmount)
+
+    const userBalanceAfter: BigNumber = await l2_hopBridgeToken.balanceOf(await user.getAddress())
+    const totalSupplyAfter: BigNumber = await l2_hopBridgeToken.totalSupply()
+
+    expect(userBalanceAfter).to.eq(userBalanceBefore.add(mintAmount))
+    expect(totalSupplyAfter).to.eq(totalSupplyBefore.add(mintAmount))
+  })
+
+  it('Should allow the owner to burn tokens', async () => {
+    // Set the owner to a known address for testing purposes
+    await l2_bridge.setHopBridgeTokenOwner(await user.getAddress())
+
+    const mintAmount: BigNumber = BigNumber.from('13371377')
+    const userBalanceBefore: BigNumber = await l2_hopBridgeToken.balanceOf(await user.getAddress())
+    const totalSupplyBefore: BigNumber = await l2_hopBridgeToken.totalSupply()
+
+    await l2_hopBridgeToken.connect(user).mint(await user.getAddress(), mintAmount)
+
+    let userBalanceAfter: BigNumber = await l2_hopBridgeToken.balanceOf(await user.getAddress())
+    let totalSupplyAfter: BigNumber = await l2_hopBridgeToken.totalSupply()
+
+    expect(userBalanceAfter).to.eq(userBalanceBefore.add(mintAmount))
+    expect(totalSupplyAfter).to.eq(totalSupplyBefore.add(mintAmount))
+
+    await l2_hopBridgeToken.connect(user).burn(await user.getAddress(), mintAmount)
+
+    userBalanceAfter = await l2_hopBridgeToken.balanceOf(await user.getAddress())
+    totalSupplyAfter = await l2_hopBridgeToken.totalSupply()
+
+    expect(userBalanceAfter).to.eq(userBalanceBefore)
+    expect(totalSupplyAfter).to.eq(totalSupplyBefore)
+  })
+
+  it('Should not allow an arbitrary address to mint tokens', async () => {
+    const expectedErrorMsg: string = 'Ownable: caller is not the owner'
+    const mintAmount: BigNumber = BigNumber.from('13371377')
+    await expect(
+      l2_hopBridgeToken.connect(user).mint(await user.getAddress(), mintAmount)
+    ).to.be.revertedWith(expectedErrorMsg)
+  })
+
+  it('Should not allow an arbitrary address to burn tokens', async () => {
+    const expectedErrorMsg: string = 'Ownable: caller is not the owner'
+    const mintAmount: BigNumber = BigNumber.from('13371377')
+    await expect(
+      l2_hopBridgeToken.connect(user).burn(await user.getAddress(), mintAmount)
+    ).to.be.revertedWith(expectedErrorMsg)
+  })
+
+})

--- a/test/bridges/L1_Bridge.test.ts
+++ b/test/bridges/L1_Bridge.test.ts
@@ -1028,7 +1028,8 @@ describe('L1_Bridge', () => {
   })
 
   describe('confirmTransferRoot', async () => {
-    it.skip('Should not allow a transfer root to be confirmed by anybody except the L2_Bridge', async () => {
+    it('Should not allow a transfer root to be confirmed by anybody except the L2_Bridge', async () => {
+      // TODO: Introduce this when `messengerWrapper.verifySender()` has been implemented
       const expectedErrorMsg: string = 'TODO'
       await executeL1BridgeSendToL2(
         l1_canonicalToken,

--- a/test/bridges/L2_Bridge.test.ts
+++ b/test/bridges/L2_Bridge.test.ts
@@ -253,6 +253,17 @@ describe('L2_Bridge', () => {
       const minimumForceCommitDelay: BigNumber = await l2_bridge.minimumForceCommitDelay()
       expect(minimumForceCommitDelay).to.eq(expectedMinimumForceCommitDelay)
     })
+
+    it('Should set a new owner of the HopBridgeToken', async () => {
+      let hopBridgeTokenOwner: string = await l2_hopBridgeToken.owner()
+      expect(hopBridgeTokenOwner).to.eq(l2_bridge.address)
+
+      const newOwner: Signer = user
+      await l2_bridge.setHopBridgeTokenOwner(await newOwner.getAddress())
+
+      hopBridgeTokenOwner = await l2_hopBridgeToken.owner()
+      expect(hopBridgeTokenOwner).to.eq(await newOwner.getAddress())
+    })
   })
 
   describe('send', async () => {


### PR DESCRIPTION
@cwhinfrey Added the ability to update the HopBridgeToken `owner`.

This would be used if we have a thriving HopBridgeToken ecosystem and want to update the L2 Bridge without needing a new Hop Bridge Token address.