### PR TITLE
Feature/internal audit 4

### DIFF
--- a/contracts/bridges/Bridge.sol
+++ b/contracts/bridges/Bridge.sol
@@ -30,8 +30,7 @@ abstract contract Bridge is Accounting {
         bytes32 indexed transferId,
         address indexed recipient,
         uint256 amount,
-        bytes32 transferNonce,
-        uint256 relayerFee
+        bytes32 transferNonce
     );
 
     event WithdrawalBonded(
@@ -177,9 +176,9 @@ abstract contract Bridge is Accounting {
 
         require(proof.verify(transferRootId, transferId), "BRG: Invalid transfer proof");
         _addToAmountWithdrawn(transferRootId, amount);
-        _fulfillWithdraw(transferId, recipient, amount, relayerFee);
+        _fulfillWithdraw(transferId, recipient, amount, uint256(0));
 
-        emit Withdrew(transferId, recipient, amount, transferNonce, relayerFee);
+        emit Withdrew(transferId, recipient, amount, transferNonce);
     }
 
     /**
@@ -322,6 +321,8 @@ abstract contract Bridge is Accounting {
     ) private {
         _markTransferSpent(transferId);
         _transferFromBridge(recipient, amount.sub(relayerFee));
-        _transferFromBridge(msg.sender, relayerFee);
+        if (relayerFee > 0) {
+            _transferFromBridge(msg.sender, relayerFee);
+        }
     }
 }

--- a/contracts/bridges/Bridge.sol
+++ b/contracts/bridges/Bridge.sol
@@ -312,7 +312,7 @@ abstract contract Bridge is Accounting {
 
     /* ========== Private Functions ========== */
 
-    /// @dev Completes the Transfer, distributes the relayer fee and marks the Transfer as spent.
+    /// @dev Completes the Transfer, distributes the Bonder fee and marks the Transfer as spent.
     function _fulfillWithdraw(
         bytes32 transferId,
         address recipient,

--- a/contracts/bridges/Bridge.sol
+++ b/contracts/bridges/Bridge.sol
@@ -38,7 +38,7 @@ abstract contract Bridge is Accounting {
         address indexed recipient,
         uint256 amount,
         bytes32 transferNonce,
-        uint256 relayerFee
+        uint256 bonderFee
     );
 
     event WithdrawalBondSettled(
@@ -72,9 +72,9 @@ abstract contract Bridge is Accounting {
      * @dev Get the hash that represents an individual Transfer.
      * @param chainId The id of the destination chain
      * @param recipient The address receiving the Transfer
-     * @param amount The amount being transferred including the `_relayerFee`
+     * @param amount The amount being transferred including the `_bonderFee`
      * @param transferNonce Used to avoid transferId collisions
-     * @param relayerFee The amount paid to the address that withdraws the Transfer
+     * @param bonderFee The amount paid to the address that withdraws the Transfer
      * @param amountOutMin The minimum amount received after attempting to swap in the destination
      * Uniswap market. 0 if no swap is intended.
      * @param deadline The deadline for swapping in the destination Uniswap market. 0 if no
@@ -85,7 +85,7 @@ abstract contract Bridge is Accounting {
         address recipient,
         uint256 amount,
         bytes32 transferNonce,
-        uint256 relayerFee,
+        uint256 bonderFee,
         uint256 amountOutMin,
         uint256 deadline
     )
@@ -98,7 +98,7 @@ abstract contract Bridge is Accounting {
             recipient,
             amount,
             transferNonce,
-            relayerFee,
+            bonderFee,
             amountOutMin,
             deadline
         ));
@@ -148,9 +148,9 @@ abstract contract Bridge is Accounting {
      * @notice Can be called by anyone (recipient or relayer)
      * @dev Withdraw a Transfer from its destination bridge
      * @param recipient The address receiving the Transfer
-     * @param amount The amount being transferred including the `_relayerFee`
+     * @param amount The amount being transferred including the `_bonderFee`
      * @param transferNonce Used to avoid transferId collisions
-     * @param relayerFee The amount paid to the address that withdraws the Transfer
+     * @param bonderFee The amount paid to the address that withdraws the Transfer
      * @param transferRootId The Merkle root of the TransferRoot
      * @param proof The Merkle proof that proves the Transfer's inclusion in the TransferRoot
      */
@@ -158,7 +158,7 @@ abstract contract Bridge is Accounting {
         address recipient,
         uint256 amount,
         bytes32 transferNonce,
-        uint256 relayerFee,
+        uint256 bonderFee,
         bytes32 transferRootId,
         bytes32[] memory proof
     )
@@ -169,7 +169,7 @@ abstract contract Bridge is Accounting {
             recipient,
             amount,
             transferNonce,
-            relayerFee,
+            bonderFee,
             0,
             0
         );
@@ -184,15 +184,15 @@ abstract contract Bridge is Accounting {
     /**
      * @dev Allows the bonder to bond individual withdrawals before their TransferRoot has been committed.
      * @param recipient The address receiving the Transfer
-     * @param amount The amount being transferred including the `_relayerFee`
+     * @param amount The amount being transferred including the `_bonderFee`
      * @param transferNonce Used to avoid transferId collisions
-     * @param relayerFee The amount paid to the address that withdraws the Transfer
+     * @param bonderFee The amount paid to the address that withdraws the Transfer
      */
     function bondWithdrawal(
         address recipient,
         uint256 amount,
         bytes32 transferNonce,
-        uint256 relayerFee
+        uint256 bonderFee
     )
         external
         onlyBonder
@@ -203,15 +203,15 @@ abstract contract Bridge is Accounting {
             recipient,
             amount,
             transferNonce,
-            relayerFee,
+            bonderFee,
             0,
             0
         );
 
         _bondWithdrawal(transferId, amount);
-        _fulfillWithdraw(transferId, recipient, amount, relayerFee);
+        _fulfillWithdraw(transferId, recipient, amount, bonderFee);
 
-        emit WithdrawalBonded(transferId, recipient, amount, transferNonce, relayerFee);
+        emit WithdrawalBonded(transferId, recipient, amount, transferNonce, bonderFee);
     }
 
     /**
@@ -317,12 +317,12 @@ abstract contract Bridge is Accounting {
         bytes32 transferId,
         address recipient,
         uint256 amount,
-        uint256 relayerFee
+        uint256 bonderFee
     ) private {
         _markTransferSpent(transferId);
-        _transferFromBridge(recipient, amount.sub(relayerFee));
-        if (relayerFee > 0) {
-            _transferFromBridge(msg.sender, relayerFee);
+        _transferFromBridge(recipient, amount.sub(bonderFee));
+        if (bonderFee > 0) {
+            _transferFromBridge(msg.sender, bonderFee);
         }
     }
 }

--- a/contracts/bridges/L1_Bridge.sol
+++ b/contracts/bridges/L1_Bridge.sol
@@ -342,8 +342,8 @@ abstract contract L1_Bridge is Bridge {
         crossDomainMessengerWrappers[chainId] = _crossDomainMessengerWrapper;
     }
 
-    function setChainIdDepositsPaused(uint256 chainId, bool paused) external onlyGovernance {
-        isChainIdPaused[chainId] = paused;
+    function setChainIdDepositsPaused(uint256 chainId, bool isPaused) external onlyGovernance {
+        isChainIdPaused[chainId] = isPaused;
     }
 
     function setChallengeAmountDivisor(uint256 _challengeAmountDivisor) external onlyGovernance {

--- a/contracts/bridges/L1_Bridge.sol
+++ b/contracts/bridges/L1_Bridge.sol
@@ -86,7 +86,8 @@ abstract contract L1_Bridge is Bridge {
     function sendToL2(
         uint256 chainId,
         address recipient,
-        uint256 amount
+        uint256 amount,
+        uint256 relayerFee
     )
         external
         payable
@@ -97,7 +98,7 @@ abstract contract L1_Bridge is Bridge {
 
         _transferToBridge(msg.sender, amount);
 
-        bytes memory mintCalldata = abi.encodeWithSignature("mint(address,uint256)", recipient, amount);
+        bytes memory mintCalldata = abi.encodeWithSignature("mint(address,uint256,uint256)", recipient, amount, relayerFee);
 
         chainBalance[chainId] = chainBalance[chainId].add(amount);
         messengerWrapper.sendCrossDomainMessage(mintCalldata);
@@ -108,7 +109,8 @@ abstract contract L1_Bridge is Bridge {
         address recipient,
         uint256 amount,
         uint256 amountOutMin,
-        uint256 deadline
+        uint256 deadline,
+        uint256 relayerFee
     )
         external
         payable
@@ -120,11 +122,12 @@ abstract contract L1_Bridge is Bridge {
         _transferToBridge(msg.sender, amount);
 
         bytes memory mintAndAttemptSwapCalldata = abi.encodeWithSignature(
-            "mintAndAttemptSwap(address,uint256,uint256,uint256)",
+            "mintAndAttemptSwap(address,uint256,uint256,uint256,uint256)",
             recipient,
             amount,
             amountOutMin,
-            deadline
+            deadline,
+            relayerFee
         );
 
         chainBalance[chainId] = chainBalance[chainId].add(amount);

--- a/contracts/bridges/L1_Bridge.sol
+++ b/contracts/bridges/L1_Bridge.sol
@@ -34,7 +34,7 @@ abstract contract L1_Bridge is Bridge {
 
     address public governance;
     mapping(uint256 => IMessengerWrapper) public crossDomainMessengerWrappers;
-    mapping(uint256 => bool) public isSendToChainIdPaused;
+    mapping(uint256 => bool) public isChainIdPaused;
     uint256 public challengeAmountMultiplier = 1;
     uint256 public challengeAmountDivisor = 10;
     uint256 public timeSlotSize = 3 hours;
@@ -94,7 +94,7 @@ abstract contract L1_Bridge is Bridge {
     {
         IMessengerWrapper messengerWrapper = crossDomainMessengerWrappers[chainId];
         require(messengerWrapper != IMessengerWrapper(0), "L1_BRG: chainId not supported");
-        require(isSendToChainIdPaused[chainId] == false, "L1_BRG: Sends to this chainId are paused");
+        require(isChainIdPaused[chainId] == false, "L1_BRG: Sends to this chainId are paused");
 
         _transferToBridge(msg.sender, amount);
 
@@ -117,7 +117,7 @@ abstract contract L1_Bridge is Bridge {
     {
         IMessengerWrapper messengerWrapper = crossDomainMessengerWrappers[chainId];
         require(messengerWrapper != IMessengerWrapper(0), "L1_BRG: chainId not supported");
-        require(isSendToChainIdPaused[chainId] == false, "L1_BRG: Sends to this chainId are paused");
+        require(isChainIdPaused[chainId] == false, "L1_BRG: Sends to this chainId are paused");
 
         _transferToBridge(msg.sender, amount);
 
@@ -343,7 +343,7 @@ abstract contract L1_Bridge is Bridge {
     }
 
     function setChainIdDepositsPaused(uint256 chainId, bool paused) external onlyGovernance {
-        isSendToChainIdPaused[chainId] = paused;
+        isChainIdPaused[chainId] = paused;
     }
 
     function setChallengeAmountDivisor(uint256 _challengeAmountDivisor) external onlyGovernance {

--- a/contracts/bridges/L1_Bridge.sol
+++ b/contracts/bridges/L1_Bridge.sol
@@ -299,7 +299,7 @@ abstract contract L1_Bridge is Bridge {
 
                 // Return the challenger's stake
                 _transferFromBridge(transferBond.challenger, challengeStakeAmount);
-                // Credit the bonder back with the bond amount plus the challenger's stake
+                // Credit the bonder back with the bond amount
                 _addCredit(transferBond.bonder, getBondForTransferAmount(transferRoot.total));
             }
         } else {

--- a/contracts/bridges/L1_Bridge.sol
+++ b/contracts/bridges/L1_Bridge.sol
@@ -33,6 +33,7 @@ abstract contract L1_Bridge is Bridge {
 
     address public governance;
     mapping(uint256 => IMessengerWrapper) public crossDomainMessengerWrappers;
+    mapping(uint256 => bool) public isSendToChainIdPaused;
     uint256 public challengeAmountMultiplier = 1;
     uint256 public challengeAmountDivisor = 10;
     uint256 public timeSlotSize = 3 hours;
@@ -89,6 +90,7 @@ abstract contract L1_Bridge is Bridge {
     {
         IMessengerWrapper messengerWrapper = crossDomainMessengerWrappers[chainId];
         require(messengerWrapper != IMessengerWrapper(0), "L1_BRG: chainId not supported");
+        require(isSendToChainIdPaused[chainId] == false, "L1_BRG: Sends to this chainId are paused");
 
         _transferToBridge(msg.sender, amount);
 
@@ -110,6 +112,7 @@ abstract contract L1_Bridge is Bridge {
     {
         IMessengerWrapper messengerWrapper = crossDomainMessengerWrappers[chainId];
         require(messengerWrapper != IMessengerWrapper(0), "L1_BRG: chainId not supported");
+        require(isSendToChainIdPaused[chainId] == false, "L1_BRG: Sends to this chainId are paused");
 
         _transferToBridge(msg.sender, amount);
 
@@ -307,6 +310,10 @@ abstract contract L1_Bridge is Bridge {
 
     function setCrossDomainMessengerWrapper(uint256 chainId, IMessengerWrapper _crossDomainMessengerWrapper) external onlyGovernance {
         crossDomainMessengerWrappers[chainId] = _crossDomainMessengerWrapper;
+    }
+
+    function setChainIdDepositsPaused(uint256 chainId, bool paused) external onlyGovernance {
+        isSendToChainIdPaused[chainId] = paused;
     }
 
     function setChallengeAmountDivisor(uint256 _challengeAmountDivisor) external onlyGovernance {

--- a/contracts/bridges/L2_Bridge.sol
+++ b/contracts/bridges/L2_Bridge.sol
@@ -26,7 +26,7 @@ abstract contract L2_Bridge is Bridge {
     uint256 public messengerGasLimit = 250000;
     uint256 public maxPendingTransfers = 100;
     uint256 public minBonderBps = 2;
-    uint256 public minBonderFeeAmount = 0;
+    uint256 public minBonderFeeAbsolute = 0;
 
     mapping(uint256 => bytes32[]) public pendingTransferIdsForChainId;
     mapping(uint256 => uint256) public pendingAmountForChainId;
@@ -103,9 +103,9 @@ abstract contract L2_Bridge is Bridge {
         require(amount > 0, "L2_BRG: Must transfer a non-zero amount");
         require(amount >= bonderFee, "L2_BRG: Relayer fee cannot exceed amount");
         require(supportedChainIds[chainId], "L2_BRG: _chainId is not supported");
-        uint256 minBonderFee = amount.mul(minBonderBps).div(10000);
-        // Get the max of minBonderFee and minBonderFeeAmount
-        minBonderFee = minBonderFee > minBonderFeeAmount ? minBonderFee : minBonderFeeAmount;
+        uint256 minBonderFeeRelative = amount.mul(minBonderBps).div(10000);
+        // Get the max of minBonderFeeRelative and minBonderFeeAbsolute
+        uint256 minBonderFee = minBonderFeeRelative > minBonderFeeAbsolute ? minBonderFeeRelative : minBonderFeeAbsolute;
         require(bonderFee >= minBonderFee, "L2_BRG: bonderFee must meet minimum requirements");
 
         bytes32[] storage pendingTransfers = pendingTransferIdsForChainId[chainId];
@@ -400,9 +400,9 @@ abstract contract L2_Bridge is Bridge {
         hToken.transferOwnership(newOwner);
     }
 
-    function setMinimumBonderFeeRequirements(uint256 _minBonderBps, uint256 _minBonderFeeAmount) external onlyGovernance {
+    function setMinimumBonderFeeRequirements(uint256 _minBonderBps, uint256 _minBonderFeeAbsolute) external onlyGovernance {
         minBonderBps = _minBonderBps;
-        minBonderFeeAmount = _minBonderFeeAmount;
+        minBonderFeeAbsolute = _minBonderFeeAbsolute;
     }
 
     /* ========== Public Getters ========== */

--- a/contracts/bridges/L2_Bridge.sol
+++ b/contracts/bridges/L2_Bridge.sol
@@ -208,7 +208,7 @@ abstract contract L2_Bridge is Bridge {
 
         require(proof.verify(rootHash, transferId), "L2_BRG: Invalid transfer proof");
         _addToAmountWithdrawn(rootHash, amount);
-        _withdrawAndAttemptSwap(transferId, recipient, amount, relayerFee, amountOutMin, deadline);
+        _withdrawAndAttemptSwap(transferId, recipient, amount, uint256(0), amountOutMin, deadline);
     }
 
     function bondWithdrawalAndAttemptSwap(
@@ -309,7 +309,9 @@ abstract contract L2_Bridge is Bridge {
     ) internal {
         _markTransferSpent(transferId);
         // distribute fee
-        _transferFromBridge(msg.sender, relayerFee);
+        if (relayerFee > 0) {
+            _transferFromBridge(msg.sender, relayerFee);
+        }
         // Attempt swap to recipient
         uint256 amountAfterFee = amount.sub(relayerFee);
         _mintAndAttemptSwap(recipient, amountAfterFee, amountOutMin, deadline);

--- a/contracts/bridges/L2_Bridge.sol
+++ b/contracts/bridges/L2_Bridge.sol
@@ -26,7 +26,7 @@ abstract contract L2_Bridge is Bridge {
     uint256 public messengerGasLimit = 250000;
     uint256 public maxPendingTransfers = 100;
     uint256 public minBonderBps = 2;
-    uint256 public minBonderFeeAmount = 6 * 1e13;
+    uint256 public minBonderFeeAmount = 0;
 
     mapping(uint256 => bytes32[]) public pendingTransferIdsForChainId;
     mapping(uint256 => uint256) public pendingAmountForChainId;

--- a/contracts/bridges/L2_Bridge.sol
+++ b/contracts/bridges/L2_Bridge.sol
@@ -89,7 +89,7 @@ abstract contract L2_Bridge is Bridge {
 
     /* ========== Public/External functions ========== */
 
-    /// @notice _amount is the amount the user wants to send plus the relayer fee
+    /// @notice _amount is the amount the user wants to send plus the Bonder fee
     function send(
         uint256 chainId,
         address recipient,
@@ -135,7 +135,7 @@ abstract contract L2_Bridge is Bridge {
         emit TransferSent(transferId, recipient, amount, transferNonce, bonderFee);
     }
 
-    /// @notice amount is the amount the user wants to send plus the relayer fee
+    /// @notice amount is the amount the user wants to send plus the Bonder fee
     function swapAndSend(
         uint256 chainId,
         address recipient,
@@ -149,7 +149,7 @@ abstract contract L2_Bridge is Bridge {
         external
         payable
     {
-        require(amount >= bonderFee, "L2_BRG: relayer fee cannot exceed amount");
+        require(amount >= bonderFee, "L2_BRG: Bonder fee cannot exceed amount");
 
         if (l2CanonicalTokenIsEth) {
             require(msg.value == amount, "L2_BRG: Value does not match amount");

--- a/contracts/bridges/L2_Bridge.sol
+++ b/contracts/bridges/L2_Bridge.sol
@@ -101,7 +101,7 @@ abstract contract L2_Bridge is Bridge {
         public
     {
         require(amount > 0, "L2_BRG: Must transfer a non-zero amount");
-        require(amount >= bonderFee, "L2_BRG: Relayer fee cannot exceed amount");
+        require(amount >= bonderFee, "L2_BRG: Bonder fee cannot exceed amount");
         require(supportedChainIds[chainId], "L2_BRG: _chainId is not supported");
         uint256 minBonderFeeRelative = amount.mul(minBonderBps).div(10000);
         // Get the max of minBonderFeeRelative and minBonderFeeAbsolute

--- a/contracts/bridges/L2_Bridge.sol
+++ b/contracts/bridges/L2_Bridge.sol
@@ -38,7 +38,8 @@ abstract contract L2_Bridge is Bridge {
 
     event TransfersCommitted (
         bytes32 indexed rootHash,
-        uint256 totalAmount
+        uint256 totalAmount,
+        uint256 rootCommittedAt
     );
 
     event TransferSent (
@@ -266,8 +267,9 @@ abstract contract L2_Bridge is Bridge {
 
         bytes32 rootHash = MerkleUtils.getMerkleRoot(pendingTransfers);
         uint256 totalAmount = pendingAmountForChainId[destinationChainId];
+        uint256 rootCommittedAt = block.timestamp;
 
-        emit TransfersCommitted(rootHash, totalAmount);
+        emit TransfersCommitted(rootHash, totalAmount, rootCommittedAt);
 
         bytes memory confirmTransferRootMessage = abi.encodeWithSignature(
             "confirmTransferRoot(uint256,bytes32,uint256,uint256,uint256)",
@@ -275,7 +277,7 @@ abstract contract L2_Bridge is Bridge {
             rootHash,
             destinationChainId,
             totalAmount,
-            block.timestamp
+            rootCommittedAt
         );
 
         delete pendingTransferIdsForChainId[destinationChainId];

--- a/contracts/bridges/L2_Bridge.sol
+++ b/contracts/bridges/L2_Bridge.sol
@@ -182,12 +182,23 @@ abstract contract L2_Bridge is Bridge {
         _commitTransfers(destinationChainId);
     }
 
-    function mint(address recipient, uint256 amount) public onlyL1Bridge {
+    function mint(address recipient, uint256 amount, uint256 relayerFee) public onlyL1Bridge {
         hToken.mint(recipient, amount);
+        hToken.mint(msg.sender, relayerFee);
     }
 
-    function mintAndAttemptSwap(address recipient, uint256 amount, uint256 amountOutMin, uint256 deadline) external onlyL1Bridge {
+    function mintAndAttemptSwap(
+        address recipient,
+        uint256 amount,
+        uint256 amountOutMin,
+        uint256 deadline,
+        uint256 relayerFee
+    )
+        external
+        onlyL1Bridge
+    {
         _mintAndAttemptSwap(recipient, amount, amountOutMin, deadline);
+        hToken.mint(msg.sender, relayerFee);
     }
 
     function withdrawAndAttemptSwap(

--- a/contracts/bridges/L2_Bridge.sol
+++ b/contracts/bridges/L2_Bridge.sol
@@ -253,11 +253,12 @@ abstract contract L2_Bridge is Bridge {
         emit TransfersCommitted(rootHash, totalAmount);
 
         bytes memory confirmTransferRootMessage = abi.encodeWithSignature(
-            "confirmTransferRoot(uint256,bytes32,uint256,uint256)",
+            "confirmTransferRoot(uint256,bytes32,uint256,uint256,uint256)",
             getChainId(),
             rootHash,
             destinationChainId,
-            totalAmount
+            totalAmount,
+            block.timestamp
         );
 
         delete pendingTransferIdsForChainId[destinationChainId];


### PR DESCRIPTION
* Add ability to pause sends to chainIds
  * Allows supported chains to be shut down
* Require TransferRoot is bonded after it is committed
  * Keeps Bonders from tricking challengers into challenging a future TransferRoot
* Only distribute relayerFee when bonding
  * Keeps outside accounts from calling withdraw and claiming relayerFee
* relayerFee -> bonderFee
  * Name change
* Add a minimum bonder fee
  * Mitigate griefing attacks from both very large sends and many small sends
* Add relayer fee for L1 -> L2 payments
  * Allows a relayer to collect a fee and recoup any L2 gas costs