### PR TITLE
Add verifySender logic and add tests

### DIFF
--- a/config/utils.ts
+++ b/config/utils.ts
@@ -6,7 +6,8 @@ import {
   ARB_CHAIN_ADDRESS,
   DEFAULT_MESSENGER_WRAPPER_SUB_MESSAGE_TYPE,
   DEFAULT_MESSENGER_WRAPPER_GAS_PRICE,
-  DEFAULT_MESSENGER_WRAPPER_GAS_CALL_VALUE
+  DEFAULT_MESSENGER_WRAPPER_GAS_CALL_VALUE,
+  ZERO_ADDRESS
 } from './constants'
 
 export const getMessengerWrapperDefaults = (
@@ -34,8 +35,10 @@ export const getMessengerWrapperDefaults = (
   } else if (isChainIdXDai(chainId)) {
     gasLimit = 1000000
 
+    // TODO: Use realistic address
     additionalData.push(
-      chainId.toString()
+      chainId.toString(),
+      ZERO_ADDRESS
     )
   }
 
@@ -78,8 +81,10 @@ export const getL2BridgeDefaults = (
     const defaultGasLimit = DEFAULT_MESSENGER_WRAPPER_GAS_LIMIT
     additionalData.push(defaultGasLimit)
   } else if (isChainIdXDai(chainId)) {
+    // TODO: Use realistic address
     const l1ChainIdBytes32 = ethersUtils.formatBytes32String(l1ChainId.toString())
     additionalData.push(l1ChainIdBytes32)
+    additionalData.push(ZERO_ADDRESS)
   }
 
   defaults.push(

--- a/contracts/bridges/L1_Bridge.sol
+++ b/contracts/bridges/L1_Bridge.sol
@@ -70,9 +70,9 @@ abstract contract L1_Bridge is Bridge {
 
     /* ========== Modifiers ========== */
 
-    modifier onlyL2Bridge(uint256 chainId, address expectedSender) {
+    modifier onlyL2Bridge(uint256 chainId) {
         IMessengerWrapper messengerWrapper = crossDomainMessengerWrappers[chainId];
-        messengerWrapper.verifySender(expectedSender, msg.data);
+        messengerWrapper.verifySender(msg.sender, msg.data);
         _;
     }
 
@@ -191,7 +191,7 @@ abstract contract L1_Bridge is Bridge {
         uint256 rootCommittedAt
     )
         external
-        onlyL2Bridge(originChainId, msg.sender)
+        onlyL2Bridge(originChainId)
     {
         bytes32 transferRootId = getTransferRootId(rootHash, totalAmount);
         require(transferRootCommittedAt[transferRootId] == 0, "L1_BRG: TransferRoot already confirmed");

--- a/contracts/bridges/L1_Bridge.sol
+++ b/contracts/bridges/L1_Bridge.sol
@@ -70,9 +70,9 @@ abstract contract L1_Bridge is Bridge {
 
     /* ========== Modifiers ========== */
 
-    modifier onlyL2Bridge(uint256 chainId) {
+    modifier onlyL2Bridge(uint256 chainId, address expectedSender) {
         IMessengerWrapper messengerWrapper = crossDomainMessengerWrappers[chainId];
-        messengerWrapper.verifySender(msg.data);
+        messengerWrapper.verifySender(expectedSender, msg.data);
         _;
     }
 
@@ -191,7 +191,7 @@ abstract contract L1_Bridge is Bridge {
         uint256 rootCommittedAt
     )
         external
-        onlyL2Bridge(originChainId)
+        onlyL2Bridge(originChainId, msg.sender)
     {
         bytes32 transferRootId = getTransferRootId(rootHash, totalAmount);
         require(transferRootCommittedAt[transferRootId] == 0, "L1_BRG: TransferRoot already confirmed");

--- a/contracts/bridges/L2_Bridge.sol
+++ b/contracts/bridges/L2_Bridge.sol
@@ -23,6 +23,7 @@ abstract contract L2_Bridge is Bridge {
     address public l1Governance;
     HopBridgeToken public hToken;
     address public l1BridgeAddress;
+    address public l1MessengerWrapperAddress;
     L2_UniswapWrapper public uniswapWrapper;
     IERC20 public l2CanonicalToken;
     mapping(uint256 => bool) public supportedChainIds;
@@ -56,7 +57,7 @@ abstract contract L2_Bridge is Bridge {
     );
 
     modifier onlyL1Bridge {
-        _verifySender(l1BridgeAddress);
+        _verifySender(l1MessengerWrapperAddress);
         _;
     }
 
@@ -296,6 +297,10 @@ abstract contract L2_Bridge is Bridge {
 
     function setL1BridgeAddress(address _l1BridgeAddress) external onlyGovernance {
         l1BridgeAddress = _l1BridgeAddress;
+    }
+
+    function setL1MessengerWrapperAddress(address _l1MessengerWrapperAddress) external onlyGovernance {
+        l1MessengerWrapperAddress = _l1MessengerWrapperAddress;
     }
 
     function setMessengerGasLimit(uint256 _messengerGasLimit) external onlyGovernance {

--- a/contracts/bridges/L2_OptimismBridge.sol
+++ b/contracts/bridges/L2_OptimismBridge.sol
@@ -47,7 +47,7 @@ contract L2_OptimismBridge is L2_Bridge {
     }
 
     function _verifySender(address expectedSender) internal override {
-        require(msg.sender == address(messenger), "L2_OVM_BRG: Caller is not l1MessengerAddress");
+        require(msg.sender == address(messenger), "L2_OVM_BRG: Caller is not the expected sender");
         // Verify that cross-domain sender is expectedSender
         require(messenger.xDomainMessageSender() == expectedSender, "L2_OVM_BRG: Invalid cross-domain sender");
     }

--- a/contracts/bridges/L2_XDaiBridge.sol
+++ b/contracts/bridges/L2_XDaiBridge.sol
@@ -14,6 +14,7 @@ contract L2_XDaiBridge is L2_Bridge {
     iArbitraryMessageBridge public messenger;
     /// @notice The xDai AMB uses bytes32 for chainId instead of uint256
     bytes32 public l1ChainId;
+    address public ambBridge;
 
     constructor (
         iArbitraryMessageBridge _messenger,
@@ -23,7 +24,8 @@ contract L2_XDaiBridge is L2_Bridge {
         address l1BridgeAddress,
         uint256[] memory supportedChainIds,
         address[] memory bonders,
-        bytes32 _l1ChainId
+        bytes32 _l1ChainId,
+        address _ambBridge
     )
         public
         L2_Bridge(
@@ -37,6 +39,7 @@ contract L2_XDaiBridge is L2_Bridge {
     {
         messenger = _messenger;
         l1ChainId = _l1ChainId;
+        ambBridge = _ambBridge;
     }
 
     function _sendCrossDomainMessage(bytes memory message) internal override {
@@ -49,6 +52,7 @@ contract L2_XDaiBridge is L2_Bridge {
 
     function _verifySender(address expectedSender) internal override {
         require(messenger.messageSender() == expectedSender);
+        require(expectedSender == ambBridge);
 
         // With the xDai AMB, it is best practice to also check the source chainId
         // https://docs.tokenbridge.net/amb-bridge/how-to-develop-xchain-apps-by-amb#receive-a-method-call-from-the-amb-bridge

--- a/contracts/bridges/L2_XDaiBridge.sol
+++ b/contracts/bridges/L2_XDaiBridge.sol
@@ -52,7 +52,7 @@ contract L2_XDaiBridge is L2_Bridge {
 
     function _verifySender(address expectedSender) internal override {
         require(messenger.messageSender() == expectedSender);
-        require(expectedSender == ambBridge);
+        require(msg.sender == ambBridge);
 
         // With the xDai AMB, it is best practice to also check the source chainId
         // https://docs.tokenbridge.net/amb-bridge/how-to-develop-xchain-apps-by-amb#receive-a-method-call-from-the-amb-bridge

--- a/contracts/interfaces/IMessengerWrapper.sol
+++ b/contracts/interfaces/IMessengerWrapper.sol
@@ -5,5 +5,5 @@ pragma experimental ABIEncoderV2;
 
 interface IMessengerWrapper {
     function sendCrossDomainMessage(bytes memory _calldata) external;
-    function verifySender(bytes memory _data) external;
+    function verifySender(address expectedSender, bytes memory _data) external;
 }

--- a/contracts/interfaces/IMessengerWrapper.sol
+++ b/contracts/interfaces/IMessengerWrapper.sol
@@ -5,5 +5,5 @@ pragma experimental ABIEncoderV2;
 
 interface IMessengerWrapper {
     function sendCrossDomainMessage(bytes memory _calldata) external;
-    function verifySender(address expectedSender, bytes memory _data) external;
+    function verifySender(address l1BridgeCaller, bytes memory _data) external;
 }

--- a/contracts/test/MockMessenger.sol
+++ b/contracts/test/MockMessenger.sol
@@ -15,29 +15,34 @@ abstract contract MockMessenger {
     struct Message {
         address target;
         bytes message;
+        address sender;
     }
 
     Message public nextMessage;
     IERC20 public canonicalToken;
+    address public xDomainMessageSender;
 
     constructor(IERC20 _canonicalToken) public {
         canonicalToken = _canonicalToken;
     }
 
     function relayNextMessage() public {
+        xDomainMessageSender = nextMessage.sender;
         (bool success, bytes memory res) = nextMessage.target.call(nextMessage.message);
         require(success, _getRevertMsgFromRes(res));
     }
 
     function receiveMessage(
         address _target,
-        bytes memory _message
+        bytes memory _message,
+        address _sender
     )
         public
     {
         nextMessage = Message(
             _target,
-            _message
+            _message,
+            _sender
         );
     }
 

--- a/contracts/test/Mock_L1_CanonicalBridge.sol
+++ b/contracts/test/Mock_L1_CanonicalBridge.sol
@@ -26,6 +26,19 @@ contract Mock_L1_CanonicalBridge {
 
     function sendMessage(
         address _target,
+        bytes memory _message
+    )
+        public
+    {
+        messenger.sendMessage(
+            _target,
+            _message,
+            uint32(0)
+        );
+    }
+
+    function sendTokens(
+        address _target,
         address _recipient,
         uint256 _amount
     )
@@ -34,10 +47,7 @@ contract Mock_L1_CanonicalBridge {
         bytes memory mintCalldata = abi.encodeWithSignature("mint(address,uint256)", _recipient, _amount);
 
         canonicalToken.safeTransferFrom(msg.sender, address(this), _amount);
-        messenger.sendMessage(
-            _target,
-            mintCalldata,
-            uint32(0)
-        );
+
+        sendMessage(_target, mintCalldata);
     }
 }

--- a/contracts/test/Mock_L1_Messenger.sol
+++ b/contracts/test/Mock_L1_Messenger.sol
@@ -28,7 +28,8 @@ contract Mock_L1_Messenger is MockMessenger {
 
         targetMessenger.receiveMessage(
             decodedTarget,
-            decodedMessage
+            decodedMessage,
+            msg.sender
         );
     }
 
@@ -76,7 +77,8 @@ contract Mock_L1_Messenger is MockMessenger {
     {
         targetMessenger.receiveMessage(
             _target,
-            _message
+            _message,
+            msg.sender
         );
     }
 }

--- a/contracts/test/Mock_L2_Messenger.sol
+++ b/contracts/test/Mock_L2_Messenger.sol
@@ -27,7 +27,8 @@ contract Mock_L2_Messenger is MockMessenger {
     {
         targetMessenger.receiveMessage(
             _destAddr,
-            _calldataForL1
+            _calldataForL1,
+            msg.sender
         );
     }
 
@@ -43,7 +44,8 @@ contract Mock_L2_Messenger is MockMessenger {
     {
         targetMessenger.receiveMessage(
             _target,
-            _message
+            _message,
+            msg.sender
         );
     }
 }

--- a/contracts/test/Mock_L2_XDaiBridge.sol
+++ b/contracts/test/Mock_L2_XDaiBridge.sol
@@ -17,7 +17,8 @@ contract Mock_L2_XDaiBridge is L2_XDaiBridge {
         address l1BridgeAddress,
         uint256[] memory supportedChainIds,
         address[] memory bonders,
-        bytes32 l1ChainId
+        bytes32 l1ChainId,
+        address ambBridge
     )
         public
         L2_XDaiBridge(
@@ -28,7 +29,8 @@ contract Mock_L2_XDaiBridge is L2_XDaiBridge {
             l1BridgeAddress,
             supportedChainIds,
             bonders,
-            l1ChainId
+            l1ChainId,
+            ambBridge
         )
     {
         chainId = _chainId;

--- a/contracts/wrappers/ArbitrumMessengerWrapper.sol
+++ b/contracts/wrappers/ArbitrumMessengerWrapper.sol
@@ -66,7 +66,7 @@ contract ArbitrumMessengerWrapper is MessengerWrapper {
         );
     }
 
-    function verifySender(address expectedSender, bytes memory _data) public override {
+    function verifySender(address l1BridgeCaller, bytes memory _data) public override {
         // ToDo: Verify sender with Arbitrum L1 messenger
         // Verify that sender is l2BridgeAddress
     }

--- a/contracts/wrappers/ArbitrumMessengerWrapper.sol
+++ b/contracts/wrappers/ArbitrumMessengerWrapper.sol
@@ -66,7 +66,7 @@ contract ArbitrumMessengerWrapper is MessengerWrapper {
         );
     }
 
-    function verifySender(bytes memory _data) public override {
+    function verifySender(address expectedSender, bytes memory _data) public override {
         // ToDo: Verify sender with Arbitrum L1 messenger
         // Verify that sender is l2BridgeAddress
     }

--- a/contracts/wrappers/ArbitrumMessengerWrapper2.sol
+++ b/contracts/wrappers/ArbitrumMessengerWrapper2.sol
@@ -47,8 +47,8 @@ contract ArbitrumMessengerWrapper is MessengerWrapper {
         arbInbox.sendContractTransaction(defaultGasLimit, defaultGasPrice, l2BridgeAddress, 0, _calldata);
     }
 
-    function verifySender(bytes memory /*_data*/) public override {
-        require(msg.sender == address(arbBridge), "ARB_MSG_WPR: Caller is not arbBridge");
+    function verifySender(address expectedSender, bytes memory /*_data*/) public override {
+        require(expectedSender == address(arbBridge), "ARB_MSG_WPR: Caller is not arbBridge");
         // Verify that sender is l2BridgeAddress
         require(IOutbox(arbBridge.activeOutbox()).l2ToL1Sender() == l2BridgeAddress, "ARB_MSG_WPR: Invalid cross-domain sender");
     }

--- a/contracts/wrappers/ArbitrumMessengerWrapper2.sol
+++ b/contracts/wrappers/ArbitrumMessengerWrapper2.sol
@@ -47,8 +47,8 @@ contract ArbitrumMessengerWrapper is MessengerWrapper {
         arbInbox.sendContractTransaction(defaultGasLimit, defaultGasPrice, l2BridgeAddress, 0, _calldata);
     }
 
-    function verifySender(address expectedSender, bytes memory /*_data*/) public override {
-        require(expectedSender == address(arbBridge), "ARB_MSG_WPR: Caller is not arbBridge");
+    function verifySender(address l1BridgeCaller, bytes memory /*_data*/) public override {
+        require(l1BridgeCaller == address(arbBridge), "ARB_MSG_WPR: Caller is not arbBridge");
         // Verify that sender is l2BridgeAddress
         require(IOutbox(arbBridge.activeOutbox()).l2ToL1Sender() == l2BridgeAddress, "ARB_MSG_WPR: Invalid cross-domain sender");
     }

--- a/contracts/wrappers/OptimismMessengerWrapper.sol
+++ b/contracts/wrappers/OptimismMessengerWrapper.sol
@@ -41,8 +41,8 @@ contract OptimismMessengerWrapper is MessengerWrapper {
         );
     }
 
-    function verifySender(bytes memory /*_data*/) public override {
-        require(msg.sender == address(l1MessengerAddress), "OVM_MSG_WPR: Caller is not l1MessengerAddress");
+    function verifySender(address expectedSender, bytes memory /*_data*/) public override {
+        require(expectedSender == address(l1MessengerAddress), "OVM_MSG_WPR: Caller is not l1MessengerAddress");
         // Verify that cross-domain sender is l2BridgeAddress
         require(l1MessengerAddress.xDomainMessageSender() == l2BridgeAddress, "OVM_MSG_WPR: Invalid cross-domain sender");
     }

--- a/contracts/wrappers/OptimismMessengerWrapper.sol
+++ b/contracts/wrappers/OptimismMessengerWrapper.sol
@@ -41,8 +41,8 @@ contract OptimismMessengerWrapper is MessengerWrapper {
         );
     }
 
-    function verifySender(address expectedSender, bytes memory /*_data*/) public override {
-        require(expectedSender == address(l1MessengerAddress), "OVM_MSG_WPR: Caller is not l1MessengerAddress");
+    function verifySender(address l1BridgeCaller, bytes memory /*_data*/) public override {
+        require(l1BridgeCaller == address(l1MessengerAddress), "OVM_MSG_WPR: Caller is not l1MessengerAddress");
         // Verify that cross-domain sender is l2BridgeAddress
         require(l1MessengerAddress.xDomainMessageSender() == l2BridgeAddress, "OVM_MSG_WPR: Invalid cross-domain sender");
     }

--- a/contracts/wrappers/XDaiMessengerWrapper.sol
+++ b/contracts/wrappers/XDaiMessengerWrapper.sol
@@ -46,7 +46,7 @@ contract XDaiMessengerWrapper is MessengerWrapper {
     }
 
     /// @notice message data is not needed for message verification with the xDai AMB
-    function verifySender(bytes memory) public override {
+    function verifySender(address, bytes memory) public override {
         require(l1MessengerAddress.messageSender() == l2BridgeAddress);
 
         // With the xDai AMB, it is best practice to also check the source chainId

--- a/contracts/wrappers/XDaiMessengerWrapper.sol
+++ b/contracts/wrappers/XDaiMessengerWrapper.sol
@@ -16,13 +16,15 @@ contract XDaiMessengerWrapper is MessengerWrapper {
     iArbitraryMessageBridge public l1MessengerAddress;
     /// @notice The xDai AMB uses bytes32 for chainId instead of uint256
     bytes32 public l2ChainId;
+    address public ambBridge;
 
     constructor(
         address _l1BridgeAddress,
         address _l2BridgeAddress,
         uint256 _defaultGasLimit,
         iArbitraryMessageBridge _l1MessengerAddress,
-        uint256 _l2ChainId
+        uint256 _l2ChainId,
+        address _ambBridge
     )
         public
     {
@@ -31,6 +33,7 @@ contract XDaiMessengerWrapper is MessengerWrapper {
         defaultGasLimit = _defaultGasLimit;
         l1MessengerAddress = _l1MessengerAddress;
         l2ChainId = bytes32(_l2ChainId);
+        ambBridge = _ambBridge;
     }
 
     /**
@@ -46,8 +49,9 @@ contract XDaiMessengerWrapper is MessengerWrapper {
     }
 
     /// @notice message data is not needed for message verification with the xDai AMB
-    function verifySender(address, bytes memory) public override {
+    function verifySender(address l1BridgeCaller, bytes memory) public override {
         require(l1MessengerAddress.messageSender() == l2BridgeAddress);
+        require(l1BridgeCaller == ambBridge);
 
         // With the xDai AMB, it is best practice to also check the source chainId
         // https://docs.tokenbridge.net/amb-bridge/how-to-develop-xchain-apps-by-amb#receive-a-method-call-from-the-amb-bridge

--- a/test/bridges/HopBridgeToken.test.ts
+++ b/test/bridges/HopBridgeToken.test.ts
@@ -17,6 +17,11 @@ import {
   DEFAULT_H_BRIDGE_TOKEN_DECIMALS
 } from '../../config/constants'
 
+import {
+  executeCanonicalBridgeSendMessage,
+  getSetHopBridgeTokenOwnerMessage
+} from '../shared/contractFunctionWrappers'
+
 describe('L1_Bridge', () => {
   let _fixture: IFixture
   let l1ChainId: BigNumber
@@ -25,8 +30,11 @@ describe('L1_Bridge', () => {
   let user: Signer
   let governance: Signer
 
+  let l1_messenger: Contract
+
   let l2_hopBridgeToken: Contract
   let l2_bridge: Contract
+  let l2_messenger: Contract
 
   let beforeAllSnapshotId: string
   let snapshotId: string
@@ -42,8 +50,10 @@ describe('L1_Bridge', () => {
     ;({
       user,
       governance,
+      l1_messenger,
       l2_hopBridgeToken,
       l2_bridge,
+      l2_messenger
     } = _fixture)
   })
 
@@ -82,7 +92,14 @@ describe('L1_Bridge', () => {
 
   it('Should allow the owner to mint tokens', async () => {
     // Set the owner to a known address for testing purposes
-    await l2_bridge.setHopBridgeTokenOwner(await user.getAddress())
+    const message: string = getSetHopBridgeTokenOwnerMessage(await user.getAddress())
+    await executeCanonicalBridgeSendMessage(
+      l1_messenger,
+      l2_bridge,
+      l2_messenger,
+      governance,
+      message
+    )
 
     const mintAmount: BigNumber = BigNumber.from('13371377')
     const userBalanceBefore: BigNumber = await l2_hopBridgeToken.balanceOf(await user.getAddress())
@@ -99,7 +116,14 @@ describe('L1_Bridge', () => {
 
   it('Should allow the owner to burn tokens', async () => {
     // Set the owner to a known address for testing purposes
-    await l2_bridge.setHopBridgeTokenOwner(await user.getAddress())
+    const message: string = getSetHopBridgeTokenOwnerMessage(await user.getAddress())
+    await executeCanonicalBridgeSendMessage(
+      l1_messenger,
+      l2_bridge,
+      l2_messenger,
+      governance,
+      message
+    )
 
     const mintAmount: BigNumber = BigNumber.from('13371377')
     const userBalanceBefore: BigNumber = await l2_hopBridgeToken.balanceOf(await user.getAddress())

--- a/test/bridges/L1_Bridge.test.ts
+++ b/test/bridges/L1_Bridge.test.ts
@@ -891,7 +891,6 @@ describe('L1_Bridge', () => {
         l2Transfer
       )
 
-      console.log('c')
       const expectedTransferIndex: BigNumber = BigNumber.from('1')
       await executeL2BridgeBondWithdrawalAndDistribute(
         l2_bridge,
@@ -905,7 +904,6 @@ describe('L1_Bridge', () => {
         expectedTransferIndex
       )
 
-      console.log('d')
       await executeL2BridgeCommitTransfers(
         l2_bridge,
         l2Transfer,
@@ -915,7 +913,6 @@ describe('L1_Bridge', () => {
       await l1_messenger.relayNextMessage()
       await l22_messenger.relayNextMessage()
 
-      console.log('e')
       const numTransfers: number = 2
       await executeBridgeSettleBondedWithdrawals(
         l22_bridge,


### PR DESCRIPTION
- Verify the correct sender in the L1 messenger wrappers
- Check the correct governance or l1 bridge address in the L2 Bridge `verifySender()` functions
- Update mock messengers to pass sender data without breaking interface
- Tests